### PR TITLE
fix: fixed object with null prototypes being ignored

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -141,7 +141,7 @@ export class Type {
 		const type = typeof value;
 		switch (type) {
 			case 'object':
-				return value === null ? 'null' : value.constructor && value.constructor.name;
+				return value === null ? 'null' : value.constructor ? value.constructor.name : 'Object';
 			case 'function':
 				return `${value.constructor.name}(${value.length}-arity)`;
 			case 'undefined':

--- a/tests/objects.test.ts
+++ b/tests/objects.test.ts
@@ -4,6 +4,11 @@ describe('Objects', () => {
 	test('object(generic)', () => {
 		expect(new Type({}).toString()).toBe('Record');
 	});
+	
+	test('object(null-prototype)', () => {
+		const foo = Object.create(null);
+		expect(new Type(foo).toString()).toBe('Record');
+	});
 
 	test('object(null)', () => {
 		expect(new Type(null).toString()).toBe('null');

--- a/tests/objects.test.ts
+++ b/tests/objects.test.ts
@@ -4,7 +4,6 @@ describe('Objects', () => {
 	test('object(generic)', () => {
 		expect(new Type({}).toString()).toBe('Record');
 	});
-	
 	test('object(null-prototype)', () => {
 		const foo = Object.create(null);
 		expect(new Type(foo).toString()).toBe('Record');


### PR DESCRIPTION
Objects with null prototypes are ignored, causing the static `resolve()` method to return `undefined` if the object has no constructor; it should fallback to the `Object` constructor to return a `Record` instead of `undefined` when coerced to a string, e.g.
```js
const { Type } = require('@sapphire/type');

const value = Object.create(null);

value.test = 1;

const type = new Type(value).toString();

console.log(type); // undefined
```