### PR TITLE
fix: triple ESM fix

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,12 +1,15 @@
-import { find } from '@discordjs/node-pre-gyp';
-import { join, resolve } from 'path';
+// Note that this is in a subfolder within src to mimick that when compiled it will be put in dist/{cjs,esm} which is
+// equally a subfolder within dist. This is to ensure that the import path to the package.json is correct.
+
+import nodePreGyp from '@discordjs/node-pre-gyp';
+import { join, resolve } from 'node:path';
 
 declare namespace Internals {
 	export function getPromiseDetails(thing: any): number[];
 	export function getProxyDetails(thing: any): number[];
 }
 
-const bindingPath = find(resolve(join(__dirname, '..', './package.json')));
+const bindingPath = nodePreGyp.find(resolve(join(__dirname, '..', '..', './package.json')));
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 export const { getPromiseDetails, getProxyDetails } = require(bindingPath) as typeof Internals;

--- a/tests/arrays.test.ts
+++ b/tests/arrays.test.ts
@@ -1,4 +1,4 @@
-import { Type } from '../src';
+import { Type } from '../src/lib/index.js';
 
 describe('Arrays', () => {
 	test('array(empty)', () => {

--- a/tests/functions.test.ts
+++ b/tests/functions.test.ts
@@ -1,4 +1,4 @@
-import { Type } from '../src';
+import { Type } from '../src/lib/index.js';
 
 describe('Functions', () => {
 	test('function(empty)', (): void => {

--- a/tests/internals.test.ts
+++ b/tests/internals.test.ts
@@ -1,4 +1,4 @@
-import { getPromiseDetails, getProxyDetails } from '../src';
+import { getPromiseDetails, getProxyDetails } from '../src/lib/index.js';
 
 describe('Internals', () => {
 	describe('getPromiseDetails', () => {

--- a/tests/maps.test.ts
+++ b/tests/maps.test.ts
@@ -1,4 +1,4 @@
-import { Type } from '../src';
+import { Type } from '../src/lib/index.js';
 
 describe('Maps', () => {
 	test('map(empty)', () => {

--- a/tests/objects.test.ts
+++ b/tests/objects.test.ts
@@ -1,4 +1,4 @@
-import { Type } from '../src';
+import { Type } from '../src/lib/index.js';
 
 describe('Objects', () => {
 	test('object(generic)', () => {

--- a/tests/primitives.test.ts
+++ b/tests/primitives.test.ts
@@ -1,4 +1,4 @@
-import { Type } from '../src';
+import { Type } from '../src/lib/index.js';
 
 describe('Primitives', () => {
 	test('number', () => {

--- a/tests/promises.test.ts
+++ b/tests/promises.test.ts
@@ -1,4 +1,4 @@
-import { Type } from '../src';
+import { Type } from '../src/lib/index.js';
 
 describe('Promises', () => {
 	test('promise(resolve)', () => {

--- a/tests/proxies.test.ts
+++ b/tests/proxies.test.ts
@@ -1,4 +1,4 @@
-import { Type } from '../src';
+import { Type } from '../src/lib/index.js';
 
 describe('Proxies', () => {
 	test('proxy(object)', () => {

--- a/tests/sets.test.ts
+++ b/tests/sets.test.ts
@@ -1,4 +1,4 @@
-import { Type } from '../src';
+import { Type } from '../src/lib/index.js';
 
 describe('Sets', () => {
 	test('set(empty)', () => {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig, type Options } from 'tsup';
 
 const baseOptions: Options = {
 	clean: true,
-	entry: ['src/index.ts'],
+	entry: ['src/lib/index.ts'],
 	dts: true,
 	minify: false,
 	skipNodeModulesBundle: true,
@@ -23,6 +23,25 @@ export default [
 	defineConfig({
 		...baseOptions,
 		outDir: 'dist/esm',
-		format: 'esm'
+		format: 'esm',
+		shims: true,
+		esbuildOptions: (options, context) => {
+			switch (context.format) {
+				case 'esm': {
+					options.banner = {
+						js: [
+							//
+							"import { createRequire } from 'node:module';",
+							'const require = createRequire(import.meta.url);'
+						].join('\n')
+					};
+					break;
+				}
+				// If it's not esm then we do nothing
+				default: {
+					break;
+				}
+			}
+		}
 	})
 ];

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://typedoc.org/schema.json",
-	"entryPoints": ["src/index.ts"],
+	"entryPoints": ["src/lib/index.ts"],
 	"json": "docs/api.json",
 	"tsconfig": "src/tsconfig.json"
 }


### PR DESCRIPTION
- fixed that we were reading the CJS specific @discordjs/node-pre-gyp with a named import which doesn't work with ESM
- fixed the path to the package.json which was now incorrect due to `dist/{cjs,esm}`
- added a `createRequire` banner to esm
- update tests to import from new path of index.ts
- update doc to import from the new path of index.ts
